### PR TITLE
superConnect to provide runSideEffects callback to connect

### DIFF
--- a/components/EmailPreview.js
+++ b/components/EmailPreview.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { connect } from 'react-redux'
+import superConnect from '../utils/superConnect'
 
 class EmailPreview extends Component {
   static populateStore(store, props) {
@@ -33,4 +33,8 @@ const mapStateToProps = function(state, existingProps) {
   }
 }
 
-export default connect(mapStateToProps)(EmailPreview);
+const runSideEffects = function() {
+  dispatch(emailApp.actions.email.ensureFreshEmails());
+}
+
+export default superConnect(runSideEffects, mapStateToProps)(EmailPreview);

--- a/components/Emails.js
+++ b/components/Emails.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react'
-import { connect } from 'react-redux'
+import superConnect from '../utils/superConnect'
 
 import MoveEmail from './MoveEmail'
 
@@ -47,8 +47,8 @@ class Emails extends Component {
 }
 
 const mapStateToProps = function(state) {
-  const emailState = state.emailApp.emails();
-  let folders = state.emailApp.folders().folders;
+  const emailState = state.emailApp.emails;
+  let folders = state.emailApp.folders.folders;
   let emails = emailState.emails;
   if(emails && folders) {
     emails = emails.map((email) => {
@@ -68,4 +68,9 @@ const mapDispatchToProps = function(dispatch) {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(Emails);
+const runSideEffects = function(state, dispatch) {
+  dispatch(emailApp.actions.folder.ensureFreshFolders());
+  dispatch(emailApp.actions.email.ensureFreshEmails());
+}
+
+export default superConnect(runSideEffects, mapStateToProps, mapDispatchToProps)(Emails);

--- a/components/Folder.js
+++ b/components/Folder.js
@@ -1,10 +1,9 @@
 import React, { Component, PropTypes } from 'react'
-import { connect } from 'react-redux'
+import superConnect from '../utils/superConnect'
 import { Link } from 'react-router'
 import emailApp from '../emailApp'
 import * as actions from '../actions'
 import MoveEmail from './MoveEmail'
-
 
 class Folder extends Component {
 
@@ -53,8 +52,8 @@ class Folder extends Component {
 }
 
 const mapStateToProps = function(state, existingProps) {
-  const foldersState = state.emailApp.folders();
-  const emailsState = state.emailApp.emails();
+  const foldersState = state.emailApp.folders;
+  const emailsState = state.emailApp.emails;
   const folder = foldersState.folders ? foldersState.folders.find((folder) => folder.id === existingProps.params.folderId) : undefined;
   const emails = emailsState.emails ? emailsState.emails.filter((email) => email.folderId === existingProps.params.folderId) : undefined;
   return {
@@ -72,4 +71,9 @@ const mapDispatchToProps = function(dispatch) {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(Folder);
+const runSideEffects = function(state, dispatch) {
+  dispatch(emailApp.actions.folder.ensureFreshFolders());
+  dispatch(emailApp.actions.email.ensureFreshEmails());
+}
+
+export default superConnect(runSideEffects, mapStateToProps, mapDispatchToProps)(Folder);

--- a/components/Folders.js
+++ b/components/Folders.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react'
-import { connect } from 'react-redux'
+import superConnect from '../utils/superConnect'
 
 import AddFolder from './AddFolder'
 import emailApp from '../emailApp'
@@ -28,7 +28,7 @@ class Folders extends Component {
 }
 
 const mapStateToProps = function(state) {
-  const foldersState = state.emailApp.folders();
+  const foldersState = state.emailApp.folders;
   return {
     folders: foldersState.folders,
     fetchedAt: foldersState.fetchedAt
@@ -41,4 +41,8 @@ const mapDispatchToProps = function(dispatch) {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(Folders);
+const runSideEffects = function(state, dispatch) {
+  dispatch(emailApp.actions.folder.ensureFreshFolders());
+}
+
+export default superConnect(runSideEffects, mapStateToProps, mapDispatchToProps)(Folders);

--- a/components/MoveEmail.js
+++ b/components/MoveEmail.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react'
-import { connect } from 'react-redux'
+import superConnect from '../utils/superConnect'
 
 import emailApp from '../emailApp'
 
@@ -38,7 +38,7 @@ class MoveEmail extends Component {
 }
 
 const mapStateToProps = function(state, existingProps) {
-  const foldersState = state.emailApp.folders();
+  const foldersState = state.emailApp.folders;
   return {
     folders: foldersState.folders
   }
@@ -50,4 +50,8 @@ const mapDispatchToProps = function(dispatch, existingProps) {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(MoveEmail);
+const runSideEffects = function(state, dispatch) {
+  dispatch(emailApp.actions.folder.ensureFreshFolders());
+}
+
+export default superConnect(runSideEffects, mapStateToProps, mapDispatchToProps)(MoveEmail);

--- a/components/OpenEmail.js
+++ b/components/OpenEmail.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react'
-import { connect } from 'react-redux'
+import superConnect from '../utils/superConnect'
+
+import emailApp from '../emailApp'
 
 class OpenEmail extends Component {
 
@@ -16,8 +18,12 @@ class OpenEmail extends Component {
 
 const mapStateToProps = function(state, existingProps) {
   return {
-    email: state.emailApp.emails().emails.find((email) => email.id === existingProps.openEmail.emailId)
+    email: state.emailApp.emails.emails.find((email) => email.id === existingProps.openEmail.emailId)
   }
 }
 
-export default connect(mapStateToProps)(OpenEmail);
+const runSideEffects = function(state, dispatch) {
+  dispatch(emailApp.actions.email.ensureFreshEmails());
+}
+
+export default superConnect(runSideEffects, mapStateToProps)(OpenEmail);

--- a/containers/App.js
+++ b/containers/App.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react'
-import { connect } from 'react-redux'
+import superConnect from '../utils/superConnect'
 import Folders from '../components/Folders'
 import OpenEmails from '../components/OpenEmails.js';
 import { Link } from 'react-router'
@@ -63,5 +63,9 @@ class App extends Component {
   }
 }
 
+const runSideEffects = function(state, dispatch) {
+  dispatch(emailApp.actions.folder.ensureFreshFolders());
+}
+
 // Wrap the component to inject dispatch and state into it
-export default connect((state) => { return { folders: state.emailApp.folders().folders } })(App)
+export default superConnect(runSideEffects, (state) => { return { folders: state.emailApp.folders.folders } })(App)

--- a/emailApp/actions/emailActions.js
+++ b/emailApp/actions/emailActions.js
@@ -27,6 +27,14 @@ export function fetchEmails() {
   }
 }
 
+export function ensureFreshEmails() {
+  return (dispatch, getState) => {
+    if(getState().emailApp.emails.dirty) {
+      dispatch(fetchEmails());
+    }
+  }
+}
+
 export function removeEmail(emailId) {
   return (dispatch) => {
     api.removeEmail(emailId);

--- a/emailApp/actions/folderActions.js
+++ b/emailApp/actions/folderActions.js
@@ -27,6 +27,14 @@ export const fetchFolders = function() {
   }
 }
 
+export const ensureFreshFolders = function() {
+  return (dispatch, getState) => {
+    if(getState().emailApp.folders.dirty) {
+      dispatch(fetchFolders());
+    }
+  }
+}
+
 export const addFolder = function(name) {
   return (dispatch) => {
     api.addFolder(name);

--- a/emailApp/reducers/emailsReducer.js
+++ b/emailApp/reducers/emailsReducer.js
@@ -6,26 +6,16 @@ const initialState = {
   dirty: true
 }
 
-const stateWrapper = function(state) {
-  return () => {
-    if(state.dirty) {
-      console.log("Fetching emails from dirty store");
-      store.dispatch(fetchEmails());
-    }
-    return state;
-  }
-}
-
-const emailsReducer = function(state = stateWrapper(initialState), action) {
+const emailsReducer = function(state = initialState, action) {
   switch(action.type) {
     case REMOVED_FOLDER:
     case REMOVED_EMAIL:
     case MOVED_EMAIL_TO_FOLDER:
       console.log("Marking emails as dirty");
-      return stateWrapper(Object.assign({}, state(), { dirty: true }));
+      return Object.assign({}, state, { dirty: true });
     case FETCHED_EMAILS:
       console.log("Fetched emails in emails reducer");
-      return stateWrapper({ emails: action.emails, dirty: false, fetchedAt: action.fetchedAt });
+      return { emails: action.emails, dirty: false, fetchedAt: action.fetchedAt };
     default:
       return state;
   }

--- a/emailApp/reducers/foldersReducer.js
+++ b/emailApp/reducers/foldersReducer.js
@@ -5,25 +5,15 @@ const initialState = {
   dirty: true
 }
 
-const stateWrapper = function(state) {
-  return () => {
-    if(state.dirty) {
-      console.log("Fetching folders from dirty store");
-      store.dispatch(fetchFolders());
-    }
-    return state;
-  }
-}
-
-const foldersReducer = function(state = stateWrapper(initialState), action) {
+const foldersReducer = function(state = initialState, action) {
   switch(action.type) {
     case ADDED_FOLDER:
     case REMOVED_FOLDER:
       console.log("Added or Removed folder in folders reducer");
-      return stateWrapper(Object.assign({}, state(), { dirty: true }));
+      return Object.assign({}, state, { dirty: true });
     case FETCHED_FOLDERS:
       console.log("Fetched folders in folders reducer");
-      return stateWrapper({ folders: action.folders, dirty: false });
+      return { folders: action.folders, dirty: false };
     default:
       return state;
   }

--- a/utils/superConnect.js
+++ b/utils/superConnect.js
@@ -1,0 +1,32 @@
+import { connect } from 'react-redux';
+
+// All of this is just monkey patching handleChange() in the connected
+// component so that it calls the `runSideEffects` function each time
+// the store notifies the component that the store state has changed.
+
+const superConnect = function(runSideEffects, mapStateToProps, mapDispatchToProps, mergeProps, options) {
+  const wrapWithConnect = connect(mapStateToProps, mapDispatchToProps, mergeProps, options)
+  return function(WrappedComponent) {
+    const ConnectedComponent = wrapWithConnect(WrappedComponent);
+    class SuperConnectedComponent extends ConnectedComponent {
+
+      handleChange() {
+        // Original behavior:
+        if (!this.unsubscribe) {
+          return
+        }
+
+        this.setState({
+          storeState: this.store.getState()
+        })
+
+        // Additional behavior:
+        runSideEffects(this.store.getState(), this.store.dispatch);
+      }
+    }
+
+    return SuperConnectedComponent;
+  }
+}
+
+export default superConnect


### PR DESCRIPTION
@jgautsch 

I am still iterating on ideas, but here is one sample solution. Rather than enhancing `mapStateToProps` with access to `dispatch`, I just added a 3rd callback to `connect`.

So, now we have `mapStateToProps`, `mapDispatchToProps`, and `runSideEffects`.

It looks something like this:

````
const runSideEffects(state, dispatch) {
  if(state.emailApp.emails.dirty) {
     dispatch(fetchEmails());
  }
}
export superConnect(runSideEffects, mapStateToProps, mapDispatchToProps)(Folder);
````

Actually, with `redux-thunk`, anything that can access `dispatch`, can indirectly access `state`, so this _could_ also be written like this:

````
const ensureFreshEmails() {
  // Just a regular thunk action creator that lives in an actions file shared somewhere
  (dispatch, getState) => {
    if(getState().emailApp.emails.dirty) {
      dispatch(fetchEmails());
    }
  }
}
const runSideEffects(state, dispatch) {
  dispatch(ensureFreshEmails());
}
export superConnect(runSideEffects, mapStateToProps, mapDispatchToProps)(Folder);

````