### PR TITLE
Use store accessor instead of storing functions in store

### DIFF
--- a/components/EmailPreview.js
+++ b/components/EmailPreview.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-
+import storeAccessor from '../utils/storeAccessor'
 class EmailPreview extends Component {
   static populateStore(store, props) {
     console.log("populating store for email preview");
@@ -29,7 +29,7 @@ class EmailPreview extends Component {
 
 const mapStateToProps = function(state, existingProps) {
   return {
-    email: state.emailApp.emails.emails.find((email) => email.id == existingProps.params.emailId)
+    email: storeAccessor.emailApp.emails().emails.find((email) => email.id == existingProps.params.emailId)
   }
 }
 

--- a/components/Emails.js
+++ b/components/Emails.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from 'react'
 import { connect } from 'react-redux'
-
+import storeAccessor from '../utils/storeAccessor'
 import MoveEmail from './MoveEmail'
 
 class Emails extends Component {
@@ -47,8 +47,8 @@ class Emails extends Component {
 }
 
 const mapStateToProps = function(state) {
-  const emailState = state.emailApp.emails();
-  let folders = state.emailApp.folders().folders;
+  const emailState = storeAccessor.emailApp.emails();
+  let folders = storeAccessor.emailApp.folders().folders;
   let emails = emailState.emails;
   if(emails && folders) {
     emails = emails.map((email) => {

--- a/components/Folder.js
+++ b/components/Folder.js
@@ -4,7 +4,7 @@ import { Link } from 'react-router'
 import emailApp from '../emailApp'
 import * as actions from '../actions'
 import MoveEmail from './MoveEmail'
-
+import storeAccessor from '../utils/storeAccessor'
 
 class Folder extends Component {
 
@@ -53,8 +53,8 @@ class Folder extends Component {
 }
 
 const mapStateToProps = function(state, existingProps) {
-  const foldersState = state.emailApp.folders();
-  const emailsState = state.emailApp.emails();
+  const foldersState = storeAccessor.emailApp.folders();
+  const emailsState = storeAccessor.emailApp.emails();
   const folder = foldersState.folders ? foldersState.folders.find((folder) => folder.id === existingProps.params.folderId) : undefined;
   const emails = emailsState.emails ? emailsState.emails.filter((email) => email.folderId === existingProps.params.folderId) : undefined;
   return {

--- a/components/Folders.js
+++ b/components/Folders.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 
 import AddFolder from './AddFolder'
 import emailApp from '../emailApp'
+import storeAccessor from '../utils/storeAccessor'
 
 class Folders extends Component {
 
@@ -28,7 +29,7 @@ class Folders extends Component {
 }
 
 const mapStateToProps = function(state) {
-  const foldersState = state.emailApp.folders();
+  const foldersState = storeAccessor.emailApp.folders();
   return {
     folders: foldersState.folders,
     fetchedAt: foldersState.fetchedAt

--- a/components/MoveEmail.js
+++ b/components/MoveEmail.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from 'react'
 import { connect } from 'react-redux'
-
+import storeAccessor from '../utils/storeAccessor'
 import emailApp from '../emailApp'
 
 class MoveEmail extends Component {
@@ -38,7 +38,7 @@ class MoveEmail extends Component {
 }
 
 const mapStateToProps = function(state, existingProps) {
-  const foldersState = state.emailApp.folders();
+  const foldersState = storeAccessor.emailApp.folders();
   return {
     folders: foldersState.folders
   }

--- a/components/OpenEmail.js
+++ b/components/OpenEmail.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 
+import storeAccessor from '../utils/storeAccessor';
+
 class OpenEmail extends Component {
 
   render() {
@@ -16,7 +18,7 @@ class OpenEmail extends Component {
 
 const mapStateToProps = function(state, existingProps) {
   return {
-    email: state.emailApp.emails().emails.find((email) => email.id === existingProps.openEmail.emailId)
+    email: storeAccessor.emailApp.emails().emails.find((email) => email.id === existingProps.openEmail.emailId)
   }
 }
 

--- a/containers/App.js
+++ b/containers/App.js
@@ -6,6 +6,8 @@ import { Link } from 'react-router'
 
 import emailApp from '../emailApp';
 
+import storeAccessor from '../utils/storeAccessor';
+
 
 class App extends Component {
   static populateStore(store, props) {
@@ -64,4 +66,4 @@ class App extends Component {
 }
 
 // Wrap the component to inject dispatch and state into it
-export default connect((state) => { return { folders: state.emailApp.folders().folders } })(App)
+export default connect((state) => { return { folders: storeAccessor.emailApp.folders().folders } })(App)

--- a/emailApp/reducers/emailsReducer.js
+++ b/emailApp/reducers/emailsReducer.js
@@ -5,27 +5,16 @@ const initialState = {
   emails: [],
   dirty: true
 }
-
-const stateWrapper = function(state) {
-  return () => {
-    if(state.dirty) {
-      console.log("Fetching emails from dirty store");
-      store.dispatch(fetchEmails());
-    }
-    return state;
-  }
-}
-
-const emailsReducer = function(state = stateWrapper(initialState), action) {
+const emailsReducer = function(state = initialState, action) {
   switch(action.type) {
     case REMOVED_FOLDER:
     case REMOVED_EMAIL:
     case MOVED_EMAIL_TO_FOLDER:
       console.log("Marking emails as dirty");
-      return stateWrapper(Object.assign({}, state(), { dirty: true }));
+      return Object.assign({}, state, { dirty: true });
     case FETCHED_EMAILS:
       console.log("Fetched emails in emails reducer");
-      return stateWrapper({ emails: action.emails, dirty: false, fetchedAt: action.fetchedAt });
+      return { emails: action.emails, dirty: false, fetchedAt: action.fetchedAt };
     default:
       return state;
   }

--- a/emailApp/reducers/foldersReducer.js
+++ b/emailApp/reducers/foldersReducer.js
@@ -5,25 +5,15 @@ const initialState = {
   dirty: true
 }
 
-const stateWrapper = function(state) {
-  return () => {
-    if(state.dirty) {
-      console.log("Fetching folders from dirty store");
-      store.dispatch(fetchFolders());
-    }
-    return state;
-  }
-}
-
-const foldersReducer = function(state = stateWrapper(initialState), action) {
+const foldersReducer = function(state = initialState, action) {
   switch(action.type) {
     case ADDED_FOLDER:
     case REMOVED_FOLDER:
       console.log("Added or Removed folder in folders reducer");
-      return stateWrapper(Object.assign({}, state(), { dirty: true }));
+      return Object.assign({}, state, { dirty: true });
     case FETCHED_FOLDERS:
       console.log("Fetched folders in folders reducer");
-      return stateWrapper({ folders: action.folders, dirty: false });
+      return { folders: action.folders, dirty: false };
     default:
       return state;
   }

--- a/index.js
+++ b/index.js
@@ -32,14 +32,12 @@ import Folder from './components/Folder'
 import Emails from './components/Emails'
 import EmailPreview from './components/EmailPreview'
 import Counter from './components/Counter'
-
+import storeAccessor from './utils/storeAccessor'
 import createBrowserHistory from 'history/lib/createBrowserHistory'
 window.emailApp = emailApp;
 const store = configureStore();
 
-// sloppy temporary hack to make
-// dispatch available in various places.
-window.store = store;
+storeAccessor.loadStore(store);
 
 const debugPanel = USE_DEV_TOOLS ? (
   <DebugPanel top right bottom>

--- a/utils/storeAccessor.js
+++ b/utils/storeAccessor.js
@@ -1,0 +1,29 @@
+import emailApp from '../emailApp'
+
+let _store = null;
+
+
+export default {
+  loadStore: function(store) {
+    _store = store;
+  },
+
+  emailApp: {
+
+    emails: function() {
+      const emails = _store.getState().emailApp.emails;
+      if(emails.dirty) {
+        _store.dispatch(emailApp.actions.email.fetchEmails());
+      }
+      return emails;
+    },
+
+    folders: function() {
+      const folders = _store.getState().emailApp.folders;
+      if(folders.dirty) {
+        _store.dispatch(emailApp.actions.folder.fetchFolders());
+      }
+      return folders;
+    }
+  }
+}


### PR DESCRIPTION
@jgautsch:

Rather than having function getters in the store itself that detect the requests and refresh stale data, we can move the function into an access object (`storeAccessor`). This keeps functions out of the store (so it's still serializable), but the components reach into state _through_ the accessor.

This may have disadvantages, but the _advantage_ is that none of the individual components (via `mapStateToProps` or `sideEffects`) need to know _that_ they need to check dirty state --- instead they just request the data they want, and the accessor refreshes stale data behind the scenes.


