### PR TITLE
Use simple-redux-router UPDATE_PATH action to reinitialize reducer state

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ import App from './containers/App'
 import configureStore, { USE_DEV_TOOLS } from './store/configureStore'
 import { Route, Router as RealRouter } from 'react-router'
 
+import { syncReduxAndRouter } from 'redux-simple-router'
+
 import * as actions from './actions/';
 
 class Router extends RealRouter {
@@ -37,6 +39,10 @@ import createBrowserHistory from 'history/lib/createBrowserHistory'
 window.emailApp = emailApp;
 const store = configureStore();
 
+const history = createBrowserHistory();
+
+syncReduxAndRouter(history, store)
+
 // sloppy temporary hack to make
 // dispatch available in various places.
 window.store = store;
@@ -51,14 +57,14 @@ let rootElement = document.getElementById('root')
 render(
   <div>
     <Provider store={store}>
-      <Router history={createBrowserHistory()}>
+      <Router history={history}>
         <Route path="/" component={App} onEnter={() => console.log("onEnter for App")}>
           <Route path="folders" component={Folders} onEnter={() => console.log("onEnter for Folders")}/>
           <Route path="emails" component={Emails} onEnter={() => console.log("onEnter for emails")}/>
           <Route path="folder/:folderId" component={Folder} onEnter={() => console.log("onEnter for folder")}>
             <Route path="email/:emailId" component={EmailPreview} onEnter={() => console.log("onEnter for EmailPreview")}/>
           </Route>
-          <Route path="counter" component={Counter} onEnter={() => store.dispatch(actions.initializeCounter())}/>
+          <Route path="counter" component={Counter}/>
         </Route>
       </Router>
     </Provider>

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -599,6 +599,11 @@
       "from": "envify@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.0.tgz"
     },
+    "errno": {
+      "version": "0.1.4",
+      "from": "errno@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz"
+    },
     "escape-html": {
       "version": "1.0.2",
       "from": "escape-html@1.0.2",
@@ -1399,6 +1404,11 @@
       "from": "proxy-addr@>=1.0.8 <1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.8.tgz"
     },
+    "prr": {
+      "version": "0.0.0",
+      "from": "prr@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+    },
     "punycode": {
       "version": "1.3.2",
       "from": "punycode@>=1.2.4 <2.0.0",
@@ -1538,6 +1548,11 @@
           "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-3.1.0.tgz"
         }
       }
+    },
+    "redux-simple-router": {
+      "version": "0.0.10",
+      "from": "redux-simple-router@>=0.0.10 <0.0.11",
+      "resolved": "https://registry.npmjs.org/redux-simple-router/-/redux-simple-router-0.0.10.tgz"
     },
     "redux-thunk": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,9 @@
     "uid": ">=0.0.2",
     "faker": ">=0.7.2",
     "lodash": "^3.10.1",
-    "history": "^1.12.0",
-    "react-router": "^1.0.0"
+    "history": "^1.13.0",
+    "react-router": "^1.0.0",
+    "redux-simple-router": "^0.0.10"
   },
   "devDependencies": {
     "babel-core": "^5.6.18",

--- a/reducers/index.js
+++ b/reducers/index.js
@@ -2,6 +2,7 @@ import { combineReducers } from 'redux'
 import emailApp from '../emailApp'
 import { OPEN_EMAIL, REMOVED_EMAIL, INCREMENT_COUNTER, INITIALIZE_COUNTER } from '../actions';
 import { FETCHED_EMAILS } from '../emailApp/actions/emailActions'
+import { UPDATE_PATH, routeReducer } from 'redux-simple-router'
 
 const openEmailsReducer = function(state = [], action) {
   switch(action.type) {
@@ -16,7 +17,9 @@ const openEmailsReducer = function(state = [], action) {
 
 const counterReducer = function(state = 0, action) {
   switch(action.type) {
-    case INITIALIZE_COUNTER:
+    case UPDATE_PATH:
+      console.log("UPDATE_PATH");
+      console.log(action);
       return 0;
     case INCREMENT_COUNTER:
       return state + 1;
@@ -33,6 +36,7 @@ const rootReducer = combineReducers({
   counter: counterReducer,
   emailApp: emailApp.reducer,
   gui: guiReducer,
+  routing: routeReducer
 });
 
 export default rootReducer;

--- a/store/configureStore.js
+++ b/store/configureStore.js
@@ -3,7 +3,7 @@ import rootReducer from '../reducers'
 import { devTools } from 'redux-devtools';
 import thunk from 'redux-thunk';
 
-export const USE_DEV_TOOLS = false;
+export const USE_DEV_TOOLS = true;
 
 export default function configureStore(initialState) {
   let composed = compose(applyMiddleware(thunk));


### PR DESCRIPTION
This is an example of using simple-redux-router UPDATE_PATH action type to signal reducers to clear out instance-specific data.