### PR TITLE
Routed Email Application, using onEnter for route page loading and state clearing

### DIFF
--- a/actions/index.js
+++ b/actions/index.js
@@ -1,0 +1,30 @@
+import uid from 'uid';
+import emailApp from '../emailApp';
+
+export const OPEN_EMAIL = 'OPEN_EMAIL';
+export const REMOVED_EMAIL = 'REMOVED_EMAIL';
+export const INCREMENT_COUNTER = 'INCREMENT_COUNTER';
+export const INITIALIZE_COUNTER = 'INITIALIZE_COUNTER';
+
+export function openEmail(emailId) {
+  return { type: OPEN_EMAIL, id: uid(), emailId: emailId };
+}
+
+export function removedEmail(emailId) {
+  return { type: REMOVED_EMAIL, emailId: emailId };
+}
+
+export function removeEmail(emailId) {
+  return (dispatch, getState) => {
+    dispatch(emailApp.actions.email.removeEmail(emailId));
+    // dispatch(removedEmail(emailId));
+  }
+}
+
+export function incrementCounter() {
+  return { type: INCREMENT_COUNTER };
+}
+
+export function initializeCounter() {
+  return { type: INITIALIZE_COUNTER };
+}

--- a/components/AddFolder.js
+++ b/components/AddFolder.js
@@ -1,0 +1,42 @@
+import React, { Component, PropTypes } from 'react'
+import { connect } from 'react-redux'
+
+import emailApp from '../emailApp'
+
+class AddFolder extends Component {
+
+  constructor(props, context) {
+    super(props, context);
+    this.state = { folderName: '' };
+  }
+
+  updateFolderName(folderName) {
+    this.setState({ folderName: folderName });
+  }
+
+  submit(e) {
+    e.preventDefault();
+    this.props.addFolder(this.state.folderName);
+    this.setState({ folderName: '' });
+  }
+
+  render() {
+    return (
+      <div>
+        <h2>Add Folder</h2>
+        <form onSubmit={(e) => this.submit(e)}>
+          <input type="text" value={this.state.folderName} onChange={(e) => this.updateFolderName(e.target.value)}/>
+          <button type="submit">Add</button>
+        </form>
+      </div>
+    )
+  }
+}
+
+const mapDispatchToProps = function(dispatch) {
+  return {
+    addFolder: (folderName) => dispatch(emailApp.actions.folder.addFolder(folderName))
+  }
+}
+
+export default connect(undefined, mapDispatchToProps)(AddFolder);

--- a/components/Counter.js
+++ b/components/Counter.js
@@ -1,0 +1,31 @@
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import * as actions from '../actions'
+
+class Counter extends Component {
+
+  render() {
+    return (
+      <div>
+        counter is {this.props.counter}
+        <button onClick={this.props.increment}>Increment</button>
+      </div>
+    )
+  }
+
+
+}
+
+const mapStateToProps = function(state) {
+  return {
+    counter: state.counter
+  }
+}
+
+const mapDispatchToProps = function(dispatch) {
+  return {
+    increment: () => dispatch(actions.incrementCounter())
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Counter);

--- a/components/EmailPreview.js
+++ b/components/EmailPreview.js
@@ -1,0 +1,32 @@
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+
+class EmailPreview extends Component {
+
+  render() {
+    console.log("Rendering email preview");
+    const { email } = this.props;
+    console.log(email);
+    if(email) {
+      return (
+        <div>
+          <h4>{email.subject}</h4>
+          <div>
+            {email.body}
+          </div>
+        </div>
+      )
+    }
+    else {
+      return <div/>;
+    }
+  }
+}
+
+const mapStateToProps = function(state, existingProps) {
+  return {
+    email: state.emailApp.emails.emails.find((email) => email.id == existingProps.params.emailId)
+  }
+}
+
+export default connect(mapStateToProps)(EmailPreview);

--- a/components/Emails.js
+++ b/components/Emails.js
@@ -1,0 +1,60 @@
+import React, { Component, PropTypes } from 'react'
+import { connect } from 'react-redux'
+
+import MoveEmail from './MoveEmail'
+
+class Emails extends Component {
+
+  render() {
+    const { emails, fetchedAt } = this.props;
+    return (
+      <div>
+        <h1>Emails (fetched at {fetchedAt}</h1><button onClick={this.props.fetchEmails}>Fetch</button>
+        <table>
+          <thead>
+            <tr>
+              <th>Subject</th>
+              <th>Sender</th>
+              <th>Folder</th>
+              <th>Delete</th>
+              <th>Move</th>
+            </tr>
+          </thead>
+          <tbody>
+            {
+              emails.map((email) => {
+                return (
+                  <tr key={email.id}>
+                    <td>{email.subject}</td>
+                    <td>{email.sender}</td>
+                    <td>{email.folderName}</td>
+                    <td><button onClick={() => this.props.removeEmail(email.id)}>Delete</button></td>
+                    <td><MoveEmail emailId={email.id}/></td>
+                  </tr>
+                )
+              })
+            }
+          </tbody>
+        </table>
+      </div>
+    )
+  }
+}
+
+const mapStateToProps = function(state) {
+  return {
+    emails: state.emailApp.emails.emails.map((email) => {
+      return Object.assign({}, email, { folderName: state.emailApp.folders.folders.find((folder) => folder.id === email.folderId).name });
+    }),
+    fetchedAt: state.emailApp.emails.fetchedAt
+  }
+}
+
+const mapDispatchToProps = function(dispatch) {
+  return {
+    fetchEmails: () => dispatch(emailApp.actions.email.fetchEmails()),
+    removeEmail: (emailId) => dispatch(emailApp.actions.email.removeEmail(emailId))
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Emails);

--- a/components/Folder.js
+++ b/components/Folder.js
@@ -1,0 +1,64 @@
+import React, { Component, PropTypes } from 'react'
+import { connect } from 'react-redux'
+import { Link } from 'react-router'
+import emailApp from '../emailApp'
+import * as actions from '../actions'
+import MoveEmail from './MoveEmail'
+
+
+class Folder extends Component {
+
+  render() {
+    const { emails, folder, fetchedAt } = this.props;
+    return (
+      <div>
+        <h1>{folder.name} (fetched at {fetchedAt}</h1><button onClick={this.props.fetchEmails}>Fetch</button>
+        <table>
+          <thead>
+            <tr>
+              <th>Subject</th>
+              <th>Sender</th>
+              <th>Delete</th>
+              <th>Move</th>
+              <th>Open</th>
+            </tr>
+          </thead>
+          <tbody>
+            {
+              emails.map((email) => {
+                return (
+                  <tr key={email.id}>
+                    <td><Link to={'/folder/' + folder.id + '/email/' + email.id}>{email.subject}</Link></td>
+                    <td>{email.sender}</td>
+                    <td><button onClick={() => this.props.removeEmail(email.id)}>Delete</button></td>
+                    <td><MoveEmail emailId={email.id}/></td>
+                    <td><button onClick={() => this.props.openEmail(email.id)}>Open</button></td>
+                  </tr>
+                )
+              })
+            }
+          </tbody>
+        </table>
+        {this.props.children}
+      </div>
+    )
+  }
+}
+
+const mapStateToProps = function(state, existingProps) {
+  return {
+    folder: state.emailApp.folders.folders.find((folder) => folder.id === existingProps.params.folderId),
+    emails: state.emailApp.emails.emails.filter((email) => email.folderId === existingProps.params.folderId),
+    fetchedAt: state.emailApp.emails.fetchedAt
+  }
+}
+
+const mapDispatchToProps = function(dispatch) {
+  return {
+    fetchEmails: () => dispatch(emailApp.actions.email.fetchEmails()),
+    removeEmail: (emailId) => dispatch(actions.removeEmail(emailId)),
+    openEmail: (emailId) => dispatch(actions.openEmail(emailId))
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Folder);

--- a/components/Folders.js
+++ b/components/Folders.js
@@ -1,0 +1,36 @@
+import React, { Component, PropTypes } from 'react'
+import { connect } from 'react-redux'
+
+import AddFolder from './AddFolder'
+import emailApp from '../emailApp'
+
+class Folders extends Component {
+
+  render() {
+    const { folders  } = this.props;
+    return (
+      <div>
+        <h1>Folders</h1>
+        <ul>
+          { folders.map((folder) => <li key={folder.id}>{folder.name} - <button onClick={() => this.props.removeFolder(folder.id)}>Delete</button></li>) }
+        </ul>
+        <AddFolder/>
+      </div>
+    )
+  }
+}
+
+const mapStateToProps = function(state) {
+  return {
+    folders: state.emailApp.folders.folders,
+    fetchedAt: state.emailApp.folders.fetchedAt
+  }
+}
+
+const mapDispatchToProps = function(dispatch) {
+  return {
+    removeFolder: (folderId) => dispatch(emailApp.actions.folder.removeFolder(folderId))
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Folders);

--- a/components/MoveEmail.js
+++ b/components/MoveEmail.js
@@ -1,0 +1,50 @@
+import React, { Component, PropTypes } from 'react'
+import { connect } from 'react-redux'
+
+import emailApp from '../emailApp'
+
+class MoveEmail extends Component {
+
+  constructor(props, context) {
+    super(props, context);
+    this.state = { selectedFolderId: props.email.folderId };
+  }
+
+  submit(e) {
+    e.preventDefault();
+    this.props.moveToFolder(this.state.selectedFolderId);
+  }
+
+  updateSelectedFolder(folderId) {
+    this.setState({ selectedFolderId: folderId });
+  }
+
+  render() {
+    const { folders, email } = this.props;
+
+    return (
+      <form onSubmit={(e) => this.submit(e)}>
+        <select onChange={(e) => this.updateSelectedFolder(e.target.value)} value={this.state.selectedFolderId}>
+          { folders.map((folder) => <option key={folder.id} value={folder.id}>{folder.name}</option> )}
+        </select>
+        <button type="submit">Move</button>
+      </form>
+    )
+  }
+}
+
+const mapStateToProps = function(state, existingProps) {
+  const email = state.emailApp.emails.emails.find((email) => email.id === existingProps.emailId);
+  return {
+    email: email,
+    folders: state.emailApp.folders.folders
+  }
+}
+
+const mapDispatchToProps = function(dispatch, existingProps) {
+  return {
+    moveToFolder: (folderId) => dispatch(emailApp.actions.email.moveEmailToFolder(existingProps.emailId, folderId))
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(MoveEmail);

--- a/components/OpenEmail.js
+++ b/components/OpenEmail.js
@@ -1,0 +1,23 @@
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+
+class OpenEmail extends Component {
+
+  render() {
+    const { openEmail, email } = this.props;
+    return (
+      <div className="openEmail">
+        <h4>{email.subject}</h4>
+        <p>{email.body}</p>
+      </div>
+    )
+  }
+}
+
+const mapStateToProps = function(state, existingProps) {
+  return {
+    email: state.emailApp.emails.emails.find((email) => email.id === existingProps.openEmail.emailId)
+  }
+}
+
+export default connect(mapStateToProps)(OpenEmail);

--- a/components/OpenEmails.js
+++ b/components/OpenEmails.js
@@ -1,0 +1,27 @@
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import OpenEmail from './OpenEmail.js';
+
+class OpenEmails extends Component {
+
+  render() {
+    const { openEmails } = this.props;
+    return (
+      <div className="openEmails">
+        {
+          openEmails.map((openEmail) => {
+            return <OpenEmail key={openEmail.id} openEmail={openEmail}/>
+          })
+        }
+      </div>
+    )
+  }
+}
+
+const mapStateToProps = function(state) {
+  return {
+    openEmails: state.gui.openEmails
+  }
+}
+
+export default connect(mapStateToProps)(OpenEmails);

--- a/containers/App.js
+++ b/containers/App.js
@@ -1,16 +1,46 @@
 import React, { Component, PropTypes } from 'react'
 import { connect } from 'react-redux'
+import Folders from '../components/Folders'
+import OpenEmails from '../components/OpenEmails.js';
+import { Link } from 'react-router'
+
 
 class App extends Component {
   render() {
-    const { dispatch } = this.props
+    const { dispatch, folders } = this.props
     return (
       <div>
-        Your App Goes Here
+        <h2>Welcome To the Email App</h2>
+        <div className="sidebar">
+          <ul>
+            <li>
+              <Link to="/folders">Folders</Link>
+              <ul>
+                {
+                  folders.map((folder) => {
+                    return (
+                      <li key={folder.id}><Link to={'/folder/' + folder.id}>{folder.name}</Link></li>
+                    )
+                  })
+                }
+              </ul>
+            </li>
+            <li>
+              <Link to="/emails">Emails</Link>
+            </li>
+            <li>
+              <Link to="/counter">Counter</Link>
+            </li>
+          </ul>
+        </div>
+        <div className="main">
+          {this.props.children}
+        </div>
+        <OpenEmails/>
       </div>
     )
   }
 }
 
 // Wrap the component to inject dispatch and state into it
-export default connect()(App)
+export default connect((state) => { return { folders: state.emailApp.folders.folders } })(App)

--- a/emailApp/actions/emailActions.js
+++ b/emailApp/actions/emailActions.js
@@ -1,0 +1,32 @@
+import { api } from '../api'
+
+window.api = api;
+
+export const FETCHED_EMAILS = 'FETCHED_EMAILS'
+
+// State action
+const fetchedEmails = function(emails, fetchedAt) {
+  return { type: FETCHED_EMAILS, emails: emails, fetchedAt: fetchedAt  };
+}
+
+// Public application API for consumption by GUI
+export function fetchEmails() {
+  return (dispatch) => {
+    const [emails, fetchedAt] = api.fetchEmails();
+    dispatch(fetchedEmails(emails, fetchedAt));
+  }
+}
+
+export function removeEmail(emailId) {
+  return (dispatch) => {
+    api.removeEmail(emailId);
+    dispatch(fetchEmails());
+  }
+}
+
+export function moveEmailToFolder(emailId, folderId) {
+  return (dispatch) => {
+    api.moveEmailToFolder(emailId, folderId);
+    dispatch(fetchEmails());
+  }
+}

--- a/emailApp/actions/folderActions.js
+++ b/emailApp/actions/folderActions.js
@@ -1,0 +1,33 @@
+import { api } from '../api'
+
+import * as emailActions from './emailActions'
+
+export const FETCHED_FOLDERS = 'FETCHED_FOLDERS'
+
+const fetchedFolders = function(folders, fetchedAt) {
+  return { type: FETCHED_FOLDERS, folders: folders, fetchedAt: fetchedAt };
+}
+
+// Public application API for consumption by GUI
+
+export const fetchFolders = function() {
+  return (dispatch) => {
+    const [folders, fetchedAt] = api.fetchFolders();
+    dispatch(fetchedFolders(folders, fetchedAt));
+  }
+}
+
+export const addFolder = function(name) {
+  return (dispatch) => {
+    api.addFolder(name)
+    dispatch(fetchFolders());
+  }
+}
+
+export const removeFolder = function(folderId) {
+  return (dispatch) => {
+    api.removeFolder(folderId);
+    dispatch(emailActions.fetchEmails());
+    dispatch(fetchFolders());
+  }
+}

--- a/emailApp/actions/index.js
+++ b/emailApp/actions/index.js
@@ -1,0 +1,5 @@
+import * as emailActions from './emailActions'
+import * as folderActions from './folderActions'
+
+export default { email: emailActions, folder: folderActions };
+

--- a/emailApp/api.js
+++ b/emailApp/api.js
@@ -1,0 +1,72 @@
+import uid from 'uid'
+import Faker from 'faker'
+import _ from 'lodash'
+window.Faker = Faker;
+// This is just the fake API so we don't
+// need a server-application running
+
+let folders = [
+                { id: '1', name: 'Inbox' },
+                { id: '2', name: "Work" },
+                { id: '3', name: "Personal" },
+                { id: '4', name: 'Archive' }
+             ]
+
+
+const fakeEmail = function(folders) {
+  return {
+    id: uid(),
+    sender: Faker.name.findName(),
+    subject: Faker.internet.domainWord(),
+    body: Faker.lorem.paragraphs(),
+    folderId: _.sample(folders.map((folder) => folder.id))
+  }
+}
+
+let emails = [];
+for(let x = 1; x < 8; x++) {
+  emails.push(fakeEmail(folders))
+}
+
+class Api {
+
+  constructor() {
+    this.emails = emails;
+    this.folders = folders;
+
+    setInterval(() => {
+      if(this.folders.length > 0) {
+        this.emails.push(fakeEmail(this.folders))
+      }
+    }, 30000);
+  }
+
+  addFolder(name) {
+    this.folders = this.folders.concat({ id: uid(), name: name });
+  }
+
+  removeFolder(folderId) {
+    this.emails = this.emails.filter((email) => email.folderId !== folderId);
+    this.folders = this.folders.filter((folder) => folder.id !== folderId);
+  }
+
+  removeEmail(emailId) {
+    this.emails = this.emails.filter((email) => email.id !== emailId);
+  }
+
+  moveEmailToFolder(emailId, folderId) {
+    const email = this.emails.find((email) => email.id === emailId);
+    email.folderId = folderId;
+  }
+
+  fetchEmails() {
+    return [this.emails, Date.now()];
+  }
+
+  fetchFolders() {
+    return [this.folders, Date.now()];
+  }
+}
+
+export const api = new Api();
+

--- a/emailApp/index.js
+++ b/emailApp/index.js
@@ -1,0 +1,10 @@
+import rootReducer from './reducers'
+
+import actions from './actions'
+
+export default { reducer: rootReducer, actions: actions }
+
+
+
+
+

--- a/emailApp/reducers/emailsReducer.js
+++ b/emailApp/reducers/emailsReducer.js
@@ -1,0 +1,12 @@
+import { FETCHED_EMAILS } from '../actions/emailActions.js';
+
+const emailsReducer = function(state = [], action) {
+  switch(action.type) {
+    case FETCHED_EMAILS:
+      return { emails: action.emails, fetchedAt: action.fetchedAt }
+    default:
+      return state;
+  }
+}
+
+export default emailsReducer;

--- a/emailApp/reducers/foldersReducer.js
+++ b/emailApp/reducers/foldersReducer.js
@@ -1,0 +1,12 @@
+import { FETCHED_FOLDERS } from '../actions/folderActions.js';
+
+const foldersReducer = function(state = [], action) {
+  switch(action.type) {
+    case FETCHED_FOLDERS:
+      return { folders: action.folders, fetchedAt: action.fetchedAt };
+    default:
+      return state;
+  }
+}
+
+export default foldersReducer;

--- a/emailApp/reducers/index.js
+++ b/emailApp/reducers/index.js
@@ -1,0 +1,11 @@
+import { combineReducers } from 'redux'
+
+import emailsReducer from '../reducers/emailsReducer.js';
+import foldersReducer from '../reducers/foldersReducer.js';
+
+const rootReducer = combineReducers({
+  emails: emailsReducer,
+  folders: foldersReducer
+});
+
+export default rootReducer;

--- a/index.html
+++ b/index.html
@@ -2,6 +2,30 @@
 <html>
   <head>
     <title>Redux Skeleton</title>
+    <style>
+      div.openEmail {
+        background-color: gray;
+        border: 1px solid black;
+        margin: 10px;
+        padding: 10px;
+        width: 300px;
+        float: left;
+      }
+      div.openEmails {
+        clear: left;
+      }
+      div.sidebar {
+        float: left;
+        width: 200px;
+        margin: 10px;
+        background-color: #cccccc;
+      }
+      div.main {
+        float: left;
+        width: 600px;
+      }
+
+    </style>
   </head>
   <body>
     <div class="app" id="root">

--- a/index.js
+++ b/index.js
@@ -4,8 +4,34 @@ import { Provider } from 'react-redux'
 import { DevTools, LogMonitor, DebugPanel } from 'redux-devtools/lib/react';
 import App from './containers/App'
 import configureStore, { USE_DEV_TOOLS } from './store/configureStore'
+import { Route, Router as RealRouter } from 'react-router'
+import * as actions from './actions/';
+import emailApp from './emailApp'
+import Folders from './components/Folders'
+import Folder from './components/Folder'
+import Emails from './components/Emails'
+import EmailPreview from './components/EmailPreview'
+import Counter from './components/Counter'
+import generatePageLoaders from './pageLoaders'
 
+class Router extends RealRouter {
+  render() {
+    console.log("Rendering Router")
+    return super.render();
+  }
+  componentDidMount() {
+    console.log("Router did mount")
+
+  }
+  componentDidUpdate() {
+    console.log("Router did update")
+  }
+}
+
+window.emailApp = emailApp;
 const store = configureStore();
+
+const pageLoaders = generatePageLoaders(store.dispatch);
 
 const debugPanel = USE_DEV_TOOLS ? (
   <DebugPanel top right bottom>
@@ -17,7 +43,16 @@ let rootElement = document.getElementById('root')
 render(
   <div>
     <Provider store={store}>
-      <App />
+      <Router>
+        <Route path="/" component={App} onEnter={pageLoaders.appShow}>
+          <Route path="folders" component={Folders} onEnter={pageLoaders.foldersIndex}/>
+          <Route path="emails" component={Emails} onEnter={pageLoaders.emailsIndex}/>
+          <Route path="folder/:folderId" component={Folder} onEnter={pageLoaders.folderShow}>
+            <Route path="email/:emailId" component={EmailPreview}/>
+          </Route>
+          <Route path="counter" component={Counter} onEnter={() => store.dispatch(actions.initializeCounter())}/>
+        </Route>
+      </Router>
     </Provider>
     {debugPanel}
   </div>,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -676,6 +676,11 @@
       "from": "extsprintf@1.0.2",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
     },
+    "faker": {
+      "version": "3.0.1",
+      "from": "faker@>=0.7.2",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-3.0.1.tgz"
+    },
     "fast-levenshtein": {
       "version": "1.0.7",
       "from": "fast-levenshtein@>=1.0.0 <1.1.0",
@@ -817,6 +822,11 @@
       "version": "3.1.2",
       "from": "hawk@>=3.1.0 <3.2.0",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz"
+    },
+    "history": {
+      "version": "1.13.1",
+      "from": "history@>=1.12.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-1.13.1.tgz"
     },
     "hoek": {
       "version": "2.16.3",
@@ -1473,6 +1483,11 @@
       "from": "react-redux@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-4.0.0.tgz"
     },
+    "react-router": {
+      "version": "1.0.0",
+      "from": "react-router@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-1.0.0.tgz"
+    },
     "readable-stream": {
       "version": "1.1.13",
       "from": "readable-stream@>=1.1.0 <1.2.0",
@@ -1523,6 +1538,11 @@
           "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-3.1.0.tgz"
         }
       }
+    },
+    "redux-thunk": {
+      "version": "1.0.0",
+      "from": "redux-thunk@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-1.0.0.tgz"
     },
     "regenerate": {
       "version": "1.2.1",
@@ -1856,6 +1876,11 @@
       "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
     },
+    "uid": {
+      "version": "0.0.2",
+      "from": "uid@>=0.0.2",
+      "resolved": "https://registry.npmjs.org/uid/-/uid-0.0.2.tgz"
+    },
     "unpipe": {
       "version": "1.0.0",
       "from": "unpipe@>=1.0.0 <1.1.0",
@@ -1900,6 +1925,11 @@
       "version": "0.0.4",
       "from": "vm-browserify@0.0.4",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz"
+    },
+    "warning": {
+      "version": "2.1.0",
+      "from": "warning@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz"
     },
     "watchpack": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,13 @@
     "react-dom": "^0.14.0",
     "react-redux": "^4.0.0",
     "redux": "^3.0.0",
-    "redux-devtools": "^2.1.5"
+    "redux-devtools": "^2.1.5",
+    "redux-thunk": "^1.0.0",
+    "uid": ">=0.0.2",
+    "faker": ">=0.7.2",
+    "lodash": "^3.10.1",
+    "history": "^1.12.0",
+    "react-router": "^1.0.0"
   },
   "devDependencies": {
     "babel-core": "^5.6.18",

--- a/pageLoaders/index.js
+++ b/pageLoaders/index.js
@@ -1,0 +1,23 @@
+import emailApp from '../emailApp'
+
+export default function generatePageLoaders(dispatch) {
+
+  return {
+
+    appShow: function() {
+      dispatch(emailApp.actions.folder.fetchFolders());
+    },
+
+    emailsIndex: function() {
+      dispatch(emailApp.actions.email.fetchEmails());
+    },
+
+    foldersIndex: function() {
+      dispatch(emailApp.actions.folder.fetchFolders());
+    },
+
+    folderShow: function() {
+      dispatch(emailApp.actions.email.fetchEmails());
+    }
+  }
+}

--- a/reducers/index.js
+++ b/reducers/index.js
@@ -1,7 +1,38 @@
 import { combineReducers } from 'redux'
+import emailApp from '../emailApp'
+import { OPEN_EMAIL, REMOVED_EMAIL, INCREMENT_COUNTER, INITIALIZE_COUNTER } from '../actions';
+import { FETCHED_EMAILS } from '../emailApp/actions/emailActions'
 
-const rootReducer = function(state = {}, action) {
-  return state;
+const openEmailsReducer = function(state = [], action) {
+  switch(action.type) {
+    case OPEN_EMAIL:
+      return state.concat({ id: action.id, emailId: action.emailId });
+    case FETCHED_EMAILS:
+      return state.filter((openEmail) => action.emails.find((email) => email.id === openEmail.emailId));
+    default:
+      return state;
+  }
 }
+
+const counterReducer = function(state = 0, action) {
+  switch(action.type) {
+    case INITIALIZE_COUNTER:
+      return 0;
+    case INCREMENT_COUNTER:
+      return state + 1;
+    default:
+      return state;
+  }
+}
+
+const guiReducer = combineReducers({
+  openEmails: openEmailsReducer
+});
+
+const rootReducer = combineReducers({
+  counter: counterReducer,
+  emailApp: emailApp.reducer,
+  gui: guiReducer,
+});
 
 export default rootReducer;

--- a/server.js
+++ b/server.js
@@ -10,7 +10,7 @@ var compiler = webpack(config)
 app.use(webpackDevMiddleware(compiler, { noInfo: true, publicPath: config.output.publicPath }))
 app.use(webpackHotMiddleware(compiler))
 
-app.get("/", function(req, res) {
+app.get("*", function(req, res) {
   res.sendFile(__dirname + '/index.html')
 })
 

--- a/store/configureStore.js
+++ b/store/configureStore.js
@@ -1,6 +1,7 @@
-import { compose, createStore } from 'redux';
+import { compose, createStore, applyMiddleware } from 'redux';
 import rootReducer from '../reducers'
 import { devTools } from 'redux-devtools';
+import thunk from 'redux-thunk';
 
 export const USE_DEV_TOOLS = true;
 
@@ -10,7 +11,6 @@ export default function configureStore(initialState) {
     composed = compose(composed, devTools());
   }
   const store = composed(createStore)(rootReducer, initialState);
-
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers
     module.hot.accept('../reducers', () => {


### PR DESCRIPTION
Rebasing a bunch of stuff in this repo.

This PR is just the code needed for the full routed email application example.

There will be several PR's into this branch to illustrate different approaches for fetching stale data and resetting instance-specific state.

This "original" branch illustrates:

1. Fetch initial data for each route with `onEnter` calling page loaders.

2. Update stale data directly from the initial action creators (i.e. every action creator needs to know which pieces of state can be affected and call the appropriate fetchers eagerly even if no components are listening.

3. Reinitializes instance-specific state (i.e. the Counter) with `onEnter`

