### PR TITLE
Use simple-redux-router UPDATE_PATH action type to clear counter

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,14 +5,21 @@ import { DevTools, LogMonitor, DebugPanel } from 'redux-devtools/lib/react';
 import App from './containers/App'
 import configureStore, { USE_DEV_TOOLS } from './store/configureStore'
 import { Route, Router as RealRouter } from 'react-router'
+
+import { syncReduxAndRouter } from 'redux-simple-router'
+
 import * as actions from './actions/';
 import emailApp from './emailApp'
+
 import Folders from './components/Folders'
 import Folder from './components/Folder'
 import Emails from './components/Emails'
 import EmailPreview from './components/EmailPreview'
 import Counter from './components/Counter'
+
 import generatePageLoaders from './pageLoaders'
+
+import createBrowserHistory from 'history/lib/createBrowserHistory'
 
 class Router extends RealRouter {
   render() {
@@ -28,10 +35,15 @@ class Router extends RealRouter {
   }
 }
 
+
 window.emailApp = emailApp;
 const store = configureStore();
 
 const pageLoaders = generatePageLoaders(store.dispatch);
+
+const history = createBrowserHistory();
+
+syncReduxAndRouter(history, store)
 
 const debugPanel = USE_DEV_TOOLS ? (
   <DebugPanel top right bottom>
@@ -43,14 +55,14 @@ let rootElement = document.getElementById('root')
 render(
   <div>
     <Provider store={store}>
-      <Router>
+      <Router history={history}>
         <Route path="/" component={App} onEnter={pageLoaders.appShow}>
           <Route path="folders" component={Folders} onEnter={pageLoaders.foldersIndex}/>
           <Route path="emails" component={Emails} onEnter={pageLoaders.emailsIndex}/>
           <Route path="folder/:folderId" component={Folder} onEnter={pageLoaders.folderShow}>
             <Route path="email/:emailId" component={EmailPreview}/>
           </Route>
-          <Route path="counter" component={Counter} onEnter={() => store.dispatch(actions.initializeCounter())}/>
+          <Route path="counter" component={Counter}/>
         </Route>
       </Router>
     </Provider>

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -599,6 +599,11 @@
       "from": "envify@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.0.tgz"
     },
+    "errno": {
+      "version": "0.1.4",
+      "from": "errno@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz"
+    },
     "escape-html": {
       "version": "1.0.2",
       "from": "escape-html@1.0.2",
@@ -1399,6 +1404,11 @@
       "from": "proxy-addr@>=1.0.8 <1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.8.tgz"
     },
+    "prr": {
+      "version": "0.0.0",
+      "from": "prr@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+    },
     "punycode": {
       "version": "1.3.2",
       "from": "punycode@>=1.2.4 <2.0.0",
@@ -1538,6 +1548,11 @@
           "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-3.1.0.tgz"
         }
       }
+    },
+    "redux-simple-router": {
+      "version": "0.0.10",
+      "from": "redux-simple-router@>=0.0.10 <0.0.11",
+      "resolved": "https://registry.npmjs.org/redux-simple-router/-/redux-simple-router-0.0.10.tgz"
     },
     "redux-thunk": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,9 @@
     "uid": ">=0.0.2",
     "faker": ">=0.7.2",
     "lodash": "^3.10.1",
-    "history": "^1.12.0",
-    "react-router": "^1.0.0"
+    "history": "^1.13.0",
+    "react-router": "^1.0.0",
+    "redux-simple-router": "^0.0.10"
   },
   "devDependencies": {
     "babel-core": "^5.6.18",

--- a/reducers/index.js
+++ b/reducers/index.js
@@ -2,6 +2,7 @@ import { combineReducers } from 'redux'
 import emailApp from '../emailApp'
 import { OPEN_EMAIL, REMOVED_EMAIL, INCREMENT_COUNTER, INITIALIZE_COUNTER } from '../actions';
 import { FETCHED_EMAILS } from '../emailApp/actions/emailActions'
+import { UPDATE_PATH, routeReducer } from 'redux-simple-router'
 
 const openEmailsReducer = function(state = [], action) {
   switch(action.type) {
@@ -16,7 +17,9 @@ const openEmailsReducer = function(state = [], action) {
 
 const counterReducer = function(state = 0, action) {
   switch(action.type) {
-    case INITIALIZE_COUNTER:
+    case UPDATE_PATH:
+      console.log("UPDATE_PATH");
+      console.log(action);
       return 0;
     case INCREMENT_COUNTER:
       return state + 1;
@@ -33,6 +36,7 @@ const rootReducer = combineReducers({
   counter: counterReducer,
   emailApp: emailApp.reducer,
   gui: guiReducer,
+  routing: routeReducer
 });
 
 export default rootReducer;


### PR DESCRIPTION
This PR illustrates how to clear instance-specific state by listening to the `UPDATE_PATH` action type triggered by `simple-redux-router`.  The basic idea is certain reducers that hold page-specific data (like insurance coverages) would pre-emptively reset themselves every time the route changes.  

This PR is only addressing how to reset state, not how to fetch stale data or initial data.

The alternative to this approach is using `onEnter` to dispatch an action that clears the state for a specific reducer.  This is the approach in the main `routed-email-app` branch.


